### PR TITLE
Moving details/links to wiki

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1333,3 +1333,10 @@ URL = {https://www.aeaweb.org/articles?id=10.1257/jep.4.2.3}}
 	publisher = {World Bank Group},
 	url = {http://documents.worldbank.org/curated/en/942491550779087507/Science-for-Impact-Better-Evidence-for-Better-Decisions-The-Dime-Experience}
 }
+
+@article{dupriez2007,
+	title={Quick Reference Guide for Data Archivists},
+	author={Dupriez, Olivier and Greenwell, Geoffrey},
+	journal={IHSN paper. http://www. ihsn. org/home/download. php},
+	year={2007}
+}

--- a/chapters/6-analysis.tex
+++ b/chapters/6-analysis.tex
@@ -408,43 +408,8 @@ as you will constantly re-order them during data analysis.
 \subsection{Visualizing data}
 
 % Useful resources for data visualization
-\textbf{Data visualization}\sidenote{\url{
-		https://dimewiki.worldbank.org/Data\_visualization}}\index{data visualization}
-is increasingly popular,
+\textbf{Data visualization} is increasingly popular,
 and is becoming a field in its own right.\cite{healy2018data,wilke2019fundamentals}
-Whole books have been written on how to create good data visualizations,
-so we will not attempt to give you advice on it.
-Rather, here are a few resources we have found useful.
-The Tapestry conference focuses on ``storytelling with data''.\sidenote{
-	\url{http://www.tapestryconference.com}}
-\textit{Fundamentals of Data Visualization} provides extensive details on practical application;\sidenote{
-	\url{https://serialmentor.com/dataviz}}
-as does \textit{Data Visualization: A Practical Introduction}.\sidenote{
-	\url{http://socvis.co}}
-Graphics tools in Stata are highly customizable.
-There is a fair amount of learning curve associated with
-extremely-fine-grained adjustment,
-but it is well worth reviewing the graphics manual.\sidenote{\url{
-		https://www.stata.com/manuals/g.pdf}}
-For an easier way around it,
-you can use built-in and user-written graph schemes.\sidenote{
-	\url{https://dimewiki.worldbank.org/Data_visualization}}
-If you are an R user, the \textit{R Graphics Cookbook}
-is a great resource for the its popular visualization package \texttt{ggplot}\sidenote{
-	\url{https://r-graphics.org} and
-	\url{https://ggplot2.tidyverse.org}}.
-But there are a variety of other visualization packages,
-such as \texttt{highcharter}, \texttt{r2d3}, \texttt{leaflet},
-and \texttt{plotly} to name a few.\sidenote{
-	\url{http://jkunst.com/highcharter},
-	\url{https://rstudio.github.io/r2d3},
-	\url{https://rstudio.github.io/leaflet} and
-	\url{https://plot.ly/r}}
-We have no intention of creating an exhaustive list,
-but these are good places to start.\sidenote{
-  \url{https://dimewiki.worldbank.org/Checklist:\_Reviewing\_Graphs}}
-
-% Writing data viz code
 We attribute some of the difficulty of creating good data visualization
 to the difficulty of writing code to create them.
 Making a visually compelling graph would already be hard enough if
@@ -461,11 +426,10 @@ discussed earlier in this chapter.
 % Stata Visual Library and ietoolkit
 Based on DIME's accumulated experience creating visualizations for impact evaluations,
 our team has developed a few resources to facilitate this workflow.
-First of all, we maintain a \textbf{Stata Visual Library}\sidenote{
-	\url{https://worldbank.github.io/Stata-IE-Visual-Library}},
-which has examples of graphs created in Stata and curated by us.\sidenote{
-	A similar resource for R is \textit{The R Graph Gallery}: \url{https://www.r-graph-gallery.com}}
-The Stata Visual Library includes example datasets to use with each do-file,
+First of all, we maintain easily-searchable data visualization libraries for both Stata\sidenote{
+	\url{https://worldbank.github.io/Stata-IE-Visual-Library}}, and R\sidenote{
+	\url{https://worldbank.github.io/r-econ-visual-library/}},.
+These libraries feature curated data visualization examples, along with source code and example datasets,
 so you get a good sense of what your data should look like
 before you can start writing code to create a visualization.
 The \texttt{ietoolkit} package also contains two commands to automate
@@ -473,6 +437,9 @@ common impact evaluation graphs:
 \texttt{iegraph} plots the values of coefficients for treatment dummies,
 and \texttt{iekdensity} displays the distribution of an outcome variable
 across groups and adds the treatment effect as a note.
+The DIME Wiki provides a list of other recommended resources and tools
+for creating good data visualizations.\sidenote{\url{
+		https://dimewiki.worldbank.org/Data\_visualization}}\index{data visualization}
 
 
 %-------------------------------------------------------------------------
@@ -720,8 +687,7 @@ discourage take up among team members who don't work with GitHub more extensivel
 Though formatted text software such as Word and PowerPoint are still prevalent,
 researchers are increasingly choosing to prepare final outputs
 like documents and presentations using {\LaTeX}.\index{LaTeX}
-{\LaTeX} is a document preparation and typesetting system with a unique code syntax.\sidenote{See
-	\url{https://www.latex-project.org} and \url{https://github.com/worldbank/DIME-LaTeX-Templates}.}
+{\LaTeX} is a document preparation and typesetting system with a unique code syntax.\sidenote{See \url{https://github.com/worldbank/DIME-LaTeX-Templates}.}
 While {\LaTeX} has a significant learning curve,
 its enormous flexibility in terms of operation, collaboration, output formatting, and styling
 make it our preferred choice for most large technical outputs.

--- a/chapters/7-publication.tex
+++ b/chapters/7-publication.tex
@@ -95,23 +95,13 @@ It also allows publishers to apply global styles and templates to already-writte
 reformatting entire documents in house styles with only a few keystrokes.
 
 % keeping it simple
-To create a {\LaTeX} document,
-you will typically start a new directory for each research output
-to hold the files and outputs for that document only.
-For a single output, we recommend putting the core document files
-(such as \texttt{main.tex} and \texttt{bibliography.bib})
-in the top-level folder,
-and then have subfolders for figures, tables, and other inputs.
-Your analysis scripts should be set up such that it is easy to output files
-to this location by adjusting paths in the master script.
-Above all, keep your workflow as simple as possible.
 While {\LaTeX} \textit{can} produce complex formatting,
 this is rarely needed for academic publishing,
 as academic manuscripts will usually be reformatted
 based on the style of the publisher.
 (By contrast, policy and other self-produced documents may desire
 extensive typesetting and investments in custom templates and formatting.)
-So, in academia at least,
+In academia at least,
 it's rarely worth the investment to go beyond basic {\LaTeX} tools:
 the title page, sections and subsections,
 figures and tables, mathematical equations,
@@ -134,26 +124,6 @@ The same principles that apply to figures and tables are therefore applied here:
 You can make changes to the references in one place (the \texttt{.bib} file),
 and then everywhere they are used they are updated correctly with one process.
 BibTeX is so widely used that it is natively integrated in Google Scholar.
-To obtain a reference in the \texttt{.bib} format for any paper you find,
-click ``BibTeX'' at the bottom of the Cite window (below the preformatted options).
-Then, copy the code directly into your \texttt{.bib} file.
-They will look like the following:
-
-\codeexample{sample.bib}{./code/sample.bib}
-
-\noindent BibTeX citations are then used as follows:
-
-\codeexample{citation.tex}{./code/citation.tex}
-
-With this tool, you can ensure that references are handled
-in a format you can manage and control.\cite{flom2005latex}
-By changing some settings in the document itself,
-you can change the style of inline citations and bibliographical references.
-You can, for example, use superscripts or author names inline,
-and order the bibiliography either by order of appearance or alphabetically.
-All the formatting and numbering will be handled automatically.
-You can also choose to display only the references which are cited in the text,
-or to include every reference in the \texttt{.bib} file.
 Since different publishers have different requirements,
 it is quite useful to be able to adapt this and other formatting very quickly,
 including through using publisher-supplied templates where available.
@@ -384,9 +354,7 @@ includes a Microdata Catalog\sidenote{
   \url{https://microdata.worldbank.org}}
 and a Geospatial Catalog,
 where researchers can publish data and documentation for their projects.\sidenote{
-  \url{https://dimewiki.worldbank.org/Microdata\_Catalog}
-\newline
-  \url{https://dimewiki.worldbank.org/Checklist:\_Microdata\_Catalog\_submission}}
+  \url{https://dimewiki.worldbank.org/Microdata\_Catalog}}
 The Harvard Dataverse publishes both data and code,
 and its Datahub for Field Experiments in Economics and Public Policy\sidenote{
 	\url{https://dataverse.harvard.edu} and
@@ -412,8 +380,7 @@ These datasets should match the survey instrument or source documentation as clo
 and should not include indicators constructed by the research team.
 Even if you do not have rights to publish the original data,
 you can typically publish derivative datasets prepared by the research team.
-These datasets usually contain only the constructed indicators and associated documentation,\sidenote{
-  \url{https://guide-for-data-archivists.readthedocs.io}}
+These datasets usually contain only the constructed indicators and associated documentation,\cite{dupriez2007}
 and should also be included in the replication package.
 
 % licensing published data
@@ -511,8 +478,7 @@ quarterly peer code review rounds, which allows research assistants to improve t
 rather than revisiting it in a rush near publication time.
 DIME projects are also expected to use Git and GitHub
 to document project work and collaboration,
-and to keep the main branch up-to-date as a working edition.\sidenote{
-	\url{https://github.com/worldbank/dime-standards}}
+and to keep the main branch up-to-date as a working edition.
 
 % ensuring code reproducibility
 Before publicly releasing a reproducibility package,
@@ -626,8 +592,7 @@ before its formal publication date, although,
 in most development research fields,
 the release of working papers is a fairly common practice.
 This can be done on a number of preprint websites,
-many of which are topic-specific.\sidenote{
-  \url{https://arxiv.org/}}
+many of which are topic-specific.
 You can also use GitHub or OSF and link to the PDF file directly
 through your personal website or whatever medium you are sharing the preprint.
 We recommend against using file sharing services such as


### PR DESCRIPTION
Removed some content / links from Chapters 6 (data viz) and 7 (latex). All the content is copied in issue #524 . I did not end up removing from the dyndoc section, that seemed ok to me. 